### PR TITLE
Fix volume boot

### DIFF
--- a/modules/node/main.tf
+++ b/modules/node/main.tf
@@ -8,6 +8,11 @@ resource "openstack_compute_servergroup_v2" "servergroup" {
   policies = [var.server_affinity]
 }
 
+data "openstack_images_image_v2" "image" {
+  name        = var.image_name
+  most_recent = true
+}
+
 resource "openstack_compute_instance_v2" "instance" {
   depends_on   = [var.node_depends_on]
   count        = var.nodes_count


### PR DESCRIPTION
Currently no `openstack_images_image_v2.image` reference exists on https://github.com/remche/terraform-openstack-rke2/blob/master/modules/node/main.tf#L49.