### PR TITLE
Rke2 config change

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -62,7 +62,7 @@
 | <a name="input_output_kubernetes_config"></a> [output\_kubernetes\_config](#input\_output\_kubernetes\_config) | Output Kubernetes config to state (for use with Kubernetes provider) | `bool` | `"false"` | no |
 | <a name="input_public_net_name"></a> [public\_net\_name](#input\_public\_net\_name) | External network name | `string` | n/a | yes |
 | <a name="input_registries_conf"></a> [registries\_conf](#input\_registries\_conf) | Containerd registries config in gz+b64 | `string` | `""` | no |
-| <a name="input_rke2_config_file"></a> [rke2\_config\_file](#input\_rke2\_config\_file) | RKE2 config file for servers | `string` | `""` | no |
+| <a name="input_rke2_config"></a> [rke2\_config](#input\_rke2\_config) | RKE2 config contents for servers | `string` | `""` | no |
 | <a name="input_rke2_version"></a> [rke2\_version](#input\_rke2\_version) | RKE2 version | `string` | `""` | no |
 | <a name="input_secgroup_rules"></a> [secgroup\_rules](#input\_secgroup\_rules) | Security group rules | `list(any)` | <pre>[<br>  {<br>    "port": 22,<br>    "protocol": "tcp",<br>    "source": "0.0.0.0/0"<br>  },<br>  {<br>    "port": 6443,<br>    "protocol": "tcp",<br>    "source": "0.0.0.0/0"<br>  },<br>  {<br>    "port": 80,<br>    "protocol": "tcp",<br>    "source": "0.0.0.0/0"<br>  },<br>  {<br>    "port": 443,<br>    "protocol": "tcp",<br>    "source": "0.0.0.0/0"<br>  }<br>]</pre> | no |
 | <a name="input_server_group_affinity"></a> [server\_group\_affinity](#input\_server\_group\_affinity) | Server group affinity | `string` | `"soft-anti-affinity"` | no |

--- a/examples/blue-green-nodes/agent.yaml.tpl
+++ b/examples/blue-green-nodes/agent.yaml.tpl
@@ -1,4 +1,5 @@
 node-label:
   - "foo=bar"
   - "something=amazing"
-
+node-taint:
+  - "app=${app_name}:NoSchedule"

--- a/examples/blue-green-nodes/main.tf
+++ b/examples/blue-green-nodes/main.tf
@@ -6,18 +6,18 @@ module "controlplane" {
   image_name       = "ubuntu-20.04-focal-x86_64"
   flavor_name      = "cpuX2"
   public_net_name  = "dmz"
-  rke2_config_file = "server.yaml"
+  rke2_config      = file("server.yaml")
   manifests_path   = "./manifests"
 }
 
 module "blue_node" {
-  source           = "remche/rke2/openstack//modules/agent"
-  image_name       = "ubuntu-20.04-focal-x86_64"
-  nodes_count      = 1
-  name_prefix      = "blue"
-  flavor_name      = "cpuX2"
-  node_config      = module.controlplane.node_config
-  rke2_config_file = "agent.yaml"
+  source      = "remche/rke2/openstack//modules/agent"
+  image_name  = "ubuntu-20.04-focal-x86_64"
+  nodes_count = 1
+  name_prefix = "blue"
+  flavor_name = "cpuX2"
+  node_config = module.controlplane.node_config
+  rke2_config = file("agent.yaml")
 }
 
 module "green_node" {

--- a/examples/blue-green-nodes/main.tf
+++ b/examples/blue-green-nodes/main.tf
@@ -17,7 +17,9 @@ module "blue_node" {
   name_prefix = "blue"
   flavor_name = "cpuX2"
   node_config = module.controlplane.node_config
-  rke2_config = file("agent.yaml")
+  rke2_config = templatefile("${path.module}/agent.yaml.tpl", {
+    app_name = "blue"
+  })
 }
 
 module "green_node" {
@@ -27,6 +29,9 @@ module "green_node" {
   name_prefix = "green"
   flavor_name = "cpuX2"
   node_config = module.controlplane.node_config
+  rke2_config = templatefile("${path.module}/agent.yaml.tpl", {
+    app_name = "green"
+  })
 }
 
 output "controlplane_floating_ip" {

--- a/examples/cloud-controller-manager/main.tf
+++ b/examples/cloud-controller-manager/main.tf
@@ -60,7 +60,7 @@ module "controlplane" {
   flavor_name      = "ec1.medium"
   public_net_name  = "external"
   nodes_count      = 1
-  rke2_config_file = "rke2_config.yaml"
+  rke2_config      = file("rke2_config.yaml")
   manifests_gzb64 = {
     "cinder-csi-plugin" : local.os_cinder_b64
     "openstack-controller-manager" : local.os_ccm_b64

--- a/examples/edge-node/main.tf
+++ b/examples/edge-node/main.tf
@@ -5,7 +5,7 @@ module "controlplane" {
   image_name       = "ubuntu-20.04-focal-x86_64"
   flavor_name      = "cpuX2"
   public_net_name  = "dmz"
-  rke2_config_file = "server.yaml"
+  rke2_config      = file("server.yaml")
   manifests_path   = "./manifests"
 }
 
@@ -17,7 +17,7 @@ module "edge_node" {
   flavor_name        = "cpuX2"
   assign_floating_ip = true
   node_config        = module.controlplane.node_config
-  rke2_config_file   = "edge.yaml"
+  rke2_config        = file("edge.yaml")
 }
 
 module "worker_node" {

--- a/examples/jupyterhub-gpu/main.tf
+++ b/examples/jupyterhub-gpu/main.tf
@@ -4,7 +4,7 @@ module "controlplane" {
   image_name       = "fg-services-ubuntu-20.04-x86_64.raw"
   flavor_name      = "m1.large-2d"
   public_net_name  = "public"
-  rke2_config_file = "server.yaml"
+  rke2_config      = file("server.yaml")
   manifests_path   = "./manifests"
   # Fix for https://github.com/rancher/rke2/issues/1113
   additional_san = ["kubernetes.default.svc"]

--- a/examples/jupyterhub/main.tf
+++ b/examples/jupyterhub/main.tf
@@ -5,7 +5,7 @@ module "controlplane" {
   image_name       = "ubuntu-20.04-focal-x86_64"
   flavor_name      = "cpuX2"
   public_net_name  = "dmz"
-  rke2_config_file = "server.yaml"
+  rke2_config      = file("server.yaml")
   manifests_path   = "./manifests"
   # Fix for https://github.com/rancher/rke2/issues/1113
   additional_san = ["kubernetes.default.svc"]

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ module "server" {
   boot_volume_size   = var.boot_volume_size
   availability_zones = var.availability_zones
   rke2_version       = var.rke2_version
-  rke2_config_file   = var.rke2_config_file
+  rke2_config        = var.rke2_config
   registries_conf    = var.registries_conf
   rke2_token         = random_string.rke2_token.result
   additional_san     = var.additional_san

--- a/modules/agent/main.tf
+++ b/modules/agent/main.tf
@@ -25,7 +25,7 @@ module "agent" {
   bastion_host       = var.node_config.bastion_host
   is_server          = false
   rke2_version       = var.rke2_version
-  rke2_config_file   = var.rke2_config_file
+  rke2_config        = var.rke2_config
   registries_conf    = var.node_config.registries_conf
   rke2_token         = var.node_config.rke2_token
   do_upgrade         = var.do_upgrade

--- a/modules/agent/variables.tf
+++ b/modules/agent/variables.tf
@@ -60,7 +60,7 @@ variable "rke2_version" {
   default = ""
 }
 
-variable "rke2_config_file" {
+variable "rke2_config" {
   type    = string
   default = ""
 }

--- a/modules/node/main.tf
+++ b/modules/node/main.tf
@@ -30,7 +30,7 @@ resource "openstack_compute_instance_v2" "instance" {
       is_server        = var.is_server
       san              = openstack_networking_floatingip_v2.floating_ip[*].address
       system_user      = var.system_user
-      rke2_conf        = var.rke2_config_file != "" ? file(var.rke2_config_file) : ""
+      rke2_conf        = var.rke2_config
       registries_conf  = var.registries_conf
       additional_san   = var.additional_san
       manifests_files  = var.manifests_path != "" ? [for f in fileset(var.manifests_path, "*.{yml,yaml}") : [f, base64gzip(file("${var.manifests_path}/${f}"))]] : []

--- a/modules/node/variables.tf
+++ b/modules/node/variables.tf
@@ -98,8 +98,9 @@ variable "rke2_version" {
   type = string
 }
 
-variable "rke2_config_file" {
-  type = string
+variable "rke2_config" {
+  type    = string
+  default = ""
 }
 
 variable "registries_conf" {

--- a/variables.tf
+++ b/variables.tf
@@ -154,10 +154,10 @@ variable "rke2_version" {
   description = "RKE2 version"
 }
 
-variable "rke2_config_file" {
+variable "rke2_config" {
   type        = string
   default     = ""
-  description = "RKE2 config file for servers"
+  description = "RKE2 config contents"
 }
 
 variable "registries_conf" {


### PR DESCRIPTION
Move the `file` function out of the module. This will allow templated file contents to be passed rather than a straight yaml file.
Change `rke2_config_file` to `rke2_config`.
```
# old
rke2_config_file = "server.yaml"

# new
rke2_config      = file("server.yaml")
rke2_config      = templatefile("${path.module}/files/controlplane.tpl", somevars)
```