### PR TITLE
Fix output_kubernetes_config

### DIFF
--- a/examples/jupyterhub-gpu/main.tf
+++ b/examples/jupyterhub-gpu/main.tf
@@ -1,11 +1,11 @@
 module "controlplane" {
-  source                 = "remche/rke2/openstack"
-  write_kubeconfig       = true
-  image_name             = "fg-services-ubuntu-20.04-x86_64.raw"
-  flavor_name            = "m1.large-2d"
-  public_net_name        = "public"
-  rke2_config            = file("server.yaml")
-  manifests_path         = "./manifests"
+  source           = "remche/rke2/openstack"
+  write_kubeconfig = true
+  image_name       = "fg-services-ubuntu-20.04-x86_64.raw"
+  flavor_name      = "m1.large-2d"
+  public_net_name  = "public"
+  rke2_config      = file("server.yaml")
+  manifests_path   = "./manifests"
   # Fix for https://github.com/rancher/rke2/issues/1113
   additional_san = ["kubernetes.default.svc"]
 }

--- a/kubernetes.tf
+++ b/kubernetes.tf
@@ -22,6 +22,9 @@ module "host" {
   version = "1.5.0"
   count   = var.output_kubernetes_config ? 1 : 0
   command = "${local.ssh} ${var.system_user}@${module.server.floating_ip[0]} sudo KUBECONFIG=/etc/rancher/rke2/rke2-remote.yaml /var/lib/rancher/rke2/bin/kubectl config view --raw=true -o jsonpath='{.clusters[0].cluster.server}'"
+  depends_on = [
+    null_resource.write_kubeconfig
+  ]
 }
 
 module "client_certificate" {
@@ -29,6 +32,9 @@ module "client_certificate" {
   version = "1.5.0"
   count   = var.output_kubernetes_config ? 1 : 0
   command = "${local.ssh} ${var.system_user}@${module.server.floating_ip[0]} sudo KUBECONFIG=/etc/rancher/rke2/rke2-remote.yaml /var/lib/rancher/rke2/bin/kubectl config view --raw=true -o jsonpath='{.users[0].user.client-certificate-data}'"
+  depends_on = [
+    null_resource.write_kubeconfig
+  ]
 }
 
 module "client_key" {
@@ -36,6 +42,9 @@ module "client_key" {
   version = "1.5.0"
   count   = var.output_kubernetes_config ? 1 : 0
   command = "${local.ssh} ${var.system_user}@${module.server.floating_ip[0]} sudo KUBECONFIG=/etc/rancher/rke2/rke2-remote.yaml /var/lib/rancher/rke2/bin/kubectl config view --raw=true -o jsonpath='{.users[0].user.client-key-data}'"
+  depends_on = [
+    null_resource.write_kubeconfig
+  ]
 }
 
 module "cluster_ca_certificate" {
@@ -43,4 +52,7 @@ module "cluster_ca_certificate" {
   version = "1.5.0"
   count   = var.output_kubernetes_config ? 1 : 0
   command = "${local.ssh} ${var.system_user}@${module.server.floating_ip[0]} sudo KUBECONFIG=/etc/rancher/rke2/rke2-remote.yaml /var/lib/rancher/rke2/bin/kubectl config view --raw=true -o jsonpath='{.clusters[0].cluster.certificate-authority-data}'"
+  depends_on = [
+    null_resource.write_kubeconfig
+  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -22,8 +22,9 @@ locals {
     registries_conf    = var.registries_conf
   }
   tmpdir           = "${path.root}/.terraform/tmp/rke2"
-  ssh              = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
-  scp              = "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+  ssh_key_arg      = var.use_ssh_agent ? "" : "-i ${var.ssh_key_file}"
+  ssh              = "ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${local.ssh_key_arg}"
+  scp              = "scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${local.ssh_key_arg}"
   remote_rke2_yaml = "${var.system_user}@${module.server.floating_ip[0]}:/etc/rancher/rke2/rke2-remote.yaml"
 }
 

--- a/modules/agent/variables.tf
+++ b/modules/agent/variables.tf
@@ -76,16 +76,16 @@ variable "do_upgrade" {
 }
 
 variable "boot_from_volume" {
-  type = bool
+  type    = bool
   default = false
 }
 
 variable "boot_volume_size" {
-  type = number
+  type    = number
   default = 20
 }
 
 variable "boot_volume_type" {
-  type = string
-  default= ""
+  type    = string
+  default = ""
 }


### PR DESCRIPTION
This PR makes the `output_kubernetes_config` wait for the `write_kubeconfig` and fixes the ssh command if you are not using an ssh-agent.

*Problem*
The `output_kubernetes_config` was not working properly. The [shell modules](https://github.com/remche/terraform-openstack-rke2/blob/5406af249de32815b36fe0daa0e0f5c243ddb548/kubernetes.tf#L20-L46) were attempting to ssh to the node before the node was ready and subsequently failing silently. Then due to no `trigger` being set, they are never run again.

You can see in the [output](https://gist.github.com/powellchristoph/3398331471f0c281bc48777f4a3315c6) that the node is still creating. The `write_kubeconfig` waits appropriately for the node to be online but the `shell` modules do not.

Also, in the tf state you can see the stderr and empty stdout.
```
~/Repos/datto/tf_rancher/clusters/shared main* ❯ tf state show 'module.shared.module.controlplane.module.host[0].null_resource.contents_if_missing'
# module.shared.module.controlplane.module.host[0].null_resource.contents_if_missing:
resource "null_resource" "contents_if_missing" {
    id       = "2317424172032125817"
    triggers = {
        "exitstatus" = "255"
        "stderr"     = ""
        "stdout"     = ""
    }
}
~/Repos/datto/tf_rancher/clusters/shared main* ❯ tf state show 'module.shared.module.controlplane.module.host[0].null_resource.contents'
# module.shared.module.controlplane.module.host[0].null_resource.contents:
resource "null_resource" "contents" {
    id       = "3765246432491133347"
    triggers = {
        "exitstatus" = "255"
        "id"         = "2291279269899936893"
        "stderr"     = "ssh: connect to host 10.41.197.105 port 22: Network is unreachable"
        "stdout"     = ""
    }
}
```