### PR TITLE
Remove netcat dependency by using curl instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Unlike [RKE version](https://github.com/remche/terraform-openstack-rke) this mod
 
 - [Terraform](https://www.terraform.io/) 0.13+
 - [OpenStack](https://docs.openstack.org/zh_CN/user-guide/common/cli-set-environment-variables-using-openstack-rc.html) environment properly sourced
-- A Openstack image fullfiling [RKE2 requirements](https://docs.rke2.io/install/requirements/) and featuring curl and nc
+- A Openstack image fullfiling [RKE2 requirements](https://docs.rke2.io/install/requirements/) and featuring curl
 - At least one Openstack floating IP
 
 ## Features

--- a/modules/node/files/cloud-init.yml.tpl
+++ b/modules/node/files/cloud-init.yml.tpl
@@ -78,7 +78,7 @@ runcmd:
   - /usr/local/bin/install-or-upgrade-rke2.sh
   %{~ if is_server ~}
     %{~ if bootstrap_server != "" ~}
-  - [ sh,  -c, 'until (nc -z ${bootstrap_server} 6443); do echo Wait for master node && sleep 10; done;']
+  - [ sh,  -c, 'until (curl -ksS -m 5 -o /dev/null https://${bootstrap_server}:6443); do echo Wait for master node && sleep 10; done;']
     %{~ endif ~}
   - systemctl enable rke2-server.service
   - systemctl start rke2-server.service


### PR DESCRIPTION
If this is the only place where netcat is used we might as well replace it with curl to reduce the number of dependencies.

For me this means I can use Debian 11 without having to install netcat first.