### PR TITLE
Ignore AZ changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,6 @@ provider "kubernetes" {
   cluster_ca_certificate = data.terraform_remote_state.rke2.outputs.kubernetes_config.cluster_ca_certificate
 }
 ```
+
+### Availability Zones
+Changes to a module's `availability_zones` will intentionally *not* cause the recreation of instances. You must manually `taint` the `module.controlplane.module.server.openstack_compute_instance_v2.instance` for force the recreation of the resource.

--- a/modules/node/main.tf
+++ b/modules/node/main.tf
@@ -68,7 +68,8 @@ resource "openstack_compute_instance_v2" "instance" {
 
   lifecycle {
     ignore_changes = [
-      user_data
+      user_data,
+      availability_zone_hints
     ]
   }
 }


### PR DESCRIPTION
I would like to ignore `availability_zone_hints` to instances. My reasoning is that it can cause unintended changes and can create a management issue. If the `AZs` are changed at all, it causes nodes to potentially be replaced.

```
  # module.iaas.module.controlplane.module.server.openstack_compute_instance_v2.instance[0] must be replaced
+/- resource "openstack_compute_instance_v2" "instance" {
      + availability_zone_hints = "use1-prod0-os-1a" # forces replacement
}
```

I believe that it would be a better user experience and more manageable if we just leave it alone. Operationally, if an `AZ` is modified it would be safer to let the admin `taint` nodes manually and recreated as required.