### PR TITLE
Deploy behind corporate proxy

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -73,7 +73,8 @@
 | <a name="input_use_ssh_agent"></a> [use\_ssh\_agent](#input\_use\_ssh\_agent) | Whether to use ssh agent | `bool` | `"true"` | no |
 | <a name="input_user_data_file"></a> [user\_data\_file](#input\_user\_data\_file) | User data file to provide when launching the instance | `string` | `null` | no |
 | <a name="input_write_kubeconfig"></a> [write\_kubeconfig](#input\_write\_kubeconfig) | Write kubeconfig file to disk | `bool` | `"false"` | no |
-
+| <a name="input_proxy_url"></a> [proxy\_url](#input\_proxy\_url) | URL like "http://user:pass@host:port" when deploying behind a proxy | `string` | `""` | no |
+| <a name="input_no_proxy"></a> [no\_proxy](#input\_no\_proxy) | Hosts to exclude from proxy (private addresses ranges are already excluded) | `list(string)` | `[]` | no |
 ## Outputs
 
 | Name | Description |

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ locals {
     rke2_token         = random_string.rke2_token.result
     registries_conf    = var.registries_conf
     proxy_url          = var.proxy_url
-    no_proxy           = var.no_proxy
+    no_proxy           = concat(["localhost","127.0.0.1","169.254.169.254","127.0.0.0/8","169.254.0.0/16","10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"], var.no_proxy)
   }
   tmpdir           = "${path.root}/.terraform/tmp/rke2"
   ssh_key_arg      = var.use_ssh_agent ? "" : "-i ${var.ssh_key_file}"
@@ -89,7 +89,7 @@ module "server" {
   manifests_gzb64        = var.manifests_gzb64
   do_upgrade             = var.do_upgrade
   proxy_url              = var.proxy_url
-  no_proxy               = var.no_proxy
+  no_proxy               = concat(["localhost","127.0.0.1","169.254.169.254","127.0.0.0/8","169.254.0.0/16","10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"], var.no_proxy)
 }
 
 resource "local_file" "tmpdirfile" {

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ locals {
     rke2_token         = random_string.rke2_token.result
     registries_conf    = var.registries_conf
     proxy_url          = var.proxy_url
-    no_proxy           = concat(["localhost","127.0.0.1","169.254.169.254","127.0.0.0/8","169.254.0.0/16","10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"], var.no_proxy)
+    no_proxy           = concat(["localhost", "127.0.0.1", "169.254.169.254", "127.0.0.0/8", "169.254.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"], var.no_proxy)
   }
   tmpdir           = "${path.root}/.terraform/tmp/rke2"
   ssh_key_arg      = var.use_ssh_agent ? "" : "-i ${var.ssh_key_file}"
@@ -89,7 +89,7 @@ module "server" {
   manifests_gzb64        = var.manifests_gzb64
   do_upgrade             = var.do_upgrade
   proxy_url              = var.proxy_url
-  no_proxy               = concat(["localhost","127.0.0.1","169.254.169.254","127.0.0.0/8","169.254.0.0/16","10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"], var.no_proxy)
+  no_proxy               = concat(["localhost", "127.0.0.1", "169.254.169.254", "127.0.0.0/8", "169.254.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"], var.no_proxy)
 }
 
 resource "local_file" "tmpdirfile" {

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,8 @@ locals {
     bastion_host       = module.server.floating_ip[0]
     rke2_token         = random_string.rke2_token.result
     registries_conf    = var.registries_conf
+    proxy_url          = var.proxy_url
+    no_proxy           = var.no_proxy
   }
   tmpdir           = "${path.root}/.terraform/tmp/rke2"
   ssh_key_arg      = var.use_ssh_agent ? "" : "-i ${var.ssh_key_file}"
@@ -86,6 +88,8 @@ module "server" {
   manifests_path         = var.manifests_path
   manifests_gzb64        = var.manifests_gzb64
   do_upgrade             = var.do_upgrade
+  proxy_url              = var.proxy_url
+  no_proxy               = var.no_proxy
 }
 
 resource "local_file" "tmpdirfile" {

--- a/modules/agent/main.tf
+++ b/modules/agent/main.tf
@@ -31,4 +31,6 @@ module "agent" {
   registries_conf        = var.node_config.registries_conf
   rke2_token             = var.node_config.rke2_token
   do_upgrade             = var.do_upgrade
+  proxy_url              = var.node_config.proxy_url
+  no_proxy               = var.node_config.no_proxy
 }

--- a/modules/agent/variables.tf
+++ b/modules/agent/variables.tf
@@ -18,6 +18,8 @@ variable "node_config" {
     rke2_token         = string
     registries_conf    = string
     bastion_host       = string
+    proxy_url          = string
+    no_proxy           = list(string)
   })
 
 }

--- a/modules/node/files/cloud-init.yml.tpl
+++ b/modules/node/files/cloud-init.yml.tpl
@@ -102,9 +102,11 @@ write_files:
     # END TERRAFORM MANAGED BLOCK
 %{ endif ~}
 runcmd:
+%{ if proxy_url != null ~}
   - export http_proxy=${proxy_url}
   - export https_proxy=${proxy_url}
-  - export no_proxy=%{ for s in no_proxy ~}${s},%{ endfor }
+  - export no_proxy=%{ for s in no_proxy ~}${s},%{ endfor }${bootstrap_server}
+%{ endif ~}
   - /usr/local/bin/install-or-upgrade-rke2.sh
   %{~ if is_server ~}
     %{~ if bootstrap_server != "" ~}

--- a/modules/node/files/cloud-init.yml.tpl
+++ b/modules/node/files/cloud-init.yml.tpl
@@ -84,6 +84,22 @@ write_files:
     ftp_proxy=${proxy_url}
     no_proxy=%{ for s in no_proxy ~}${s},%{ endfor }
     # END TERRAFORM MANAGED BLOCK
+- path: /etc/default/rke2-server
+  append: true
+  content: |
+    # BEGIN TERRAFORM MANAGED BLOCK
+    HTTP_PROXY=${proxy_url}
+    HTTPS_PROXY=${proxy_url}
+    NO_PROXY=%{ for s in no_proxy ~}${s},%{ endfor }
+    # END TERRAFORM MANAGED BLOCK
+- path: /etc/default/rke2-agent
+  append: true
+  content: |
+    # BEGIN TERRAFORM MANAGED BLOCK
+    HTTP_PROXY=${proxy_url}
+    HTTPS_PROXY=${proxy_url}
+    NO_PROXY=%{ for s in no_proxy ~}${s},%{ endfor }
+    # END TERRAFORM MANAGED BLOCK
 %{ endif ~}
 runcmd:
   - /usr/local/bin/install-or-upgrade-rke2.sh

--- a/modules/node/files/cloud-init.yml.tpl
+++ b/modules/node/files/cloud-init.yml.tpl
@@ -102,6 +102,9 @@ write_files:
     # END TERRAFORM MANAGED BLOCK
 %{ endif ~}
 runcmd:
+  - export http_proxy=${proxy_url}
+  - export https_proxy=${proxy_url}
+  - export no_proxy=%{ for s in no_proxy ~}${s},%{ endfor }
   - /usr/local/bin/install-or-upgrade-rke2.sh
   %{~ if is_server ~}
     %{~ if bootstrap_server != "" ~}

--- a/modules/node/files/cloud-init.yml.tpl
+++ b/modules/node/files/cloud-init.yml.tpl
@@ -74,6 +74,17 @@ write_files:
     kube-apiserver-arg: "kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"
     %{~ endif ~}
     ${indent(4,rke2_conf)}
+%{ if proxy_url != null ~}
+- path: /etc/environment
+  append: true
+  content: |
+    # BEGIN TERRAFORM MANAGED BLOCK
+    http_proxy=${proxy_url}
+    https_proxy=${proxy_url}
+    ftp_proxy=${proxy_url}
+    no_proxy=%{ for s in no_proxy ~}${s},%{ endfor }
+    # END TERRAFORM MANAGED BLOCK
+%{ endif ~}
 runcmd:
   - /usr/local/bin/install-or-upgrade-rke2.sh
   %{~ if is_server ~}

--- a/modules/node/main.tf
+++ b/modules/node/main.tf
@@ -36,6 +36,8 @@ resource "openstack_compute_instance_v2" "instance" {
       additional_san   = var.additional_san
       manifests_files  = var.manifests_path != "" ? [for f in fileset(var.manifests_path, "*.{yml,yaml}") : [f, base64gzip(file("${var.manifests_path}/${f}"))]] : []
       manifests_gzb64  = var.manifests_gzb64
+      proxy_url        = var.proxy_url
+      no_proxy         = var.no_proxy
   }))
   metadata = {
     rke2_version = var.rke2_version

--- a/modules/node/variables.tf
+++ b/modules/node/variables.tf
@@ -163,10 +163,10 @@ variable "do_upgrade" {
 
 variable "proxy_url" {
   type    = string
-  default = ""
+  default = null
 }
 
 variable "no_proxy" {
   type    = list(string)
-  default = ["localhost","127.0.0.0/8","10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]
+  default = []
 }

--- a/modules/node/variables.tf
+++ b/modules/node/variables.tf
@@ -160,3 +160,13 @@ variable "manifests_gzb64" {
 variable "do_upgrade" {
   type = bool
 }
+
+variable "proxy_url" {
+  type    = string
+  default = ""
+}
+
+variable "no_proxy" {
+  type    = list(string)
+  default = ["localhost","127.0.0.0/8","10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,18 @@ variable "output_kubernetes_config" {
   description = "Output Kubernetes config to state (for use with Kubernetes provider)"
 }
 
+variable "proxy_url" {
+  type        = string
+  default     = null
+  description = "URL of proxy server"
+}
+
+variable "no_proxy" {
+  type        = list(string)
+  default     = ["localhost","127.0.0.0/8","10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]
+  description = "Hosts that should not be proxied"
+}
+
 ######################
 # Secgroup variables #
 ######################

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,7 @@ variable "proxy_url" {
 
 variable "no_proxy" {
   type        = list(string)
-  default     = ["localhost","127.0.0.0/8","10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]
+  default     = ["localhost","127.0.0.1","169.254.169.254","127.0.0.0/8","169.254.0.0/16","10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]
   description = "Hosts that should not be proxied"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,7 @@ variable "proxy_url" {
 
 variable "no_proxy" {
   type        = list(string)
-  default     = ["localhost","127.0.0.1","169.254.169.254","127.0.0.0/8","169.254.0.0/16","10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"]
+  default     = []
   description = "Hosts that should not be proxied"
 }
 


### PR DESCRIPTION
Add variables `proxy_url` and `no_proxy` to deploy behind a coporate proxy.
`no_proxy` already contains private addresses ranges which should be excluded.
Anyone seeking to use these variables should only need to add their organization's DNS domain (that of the Keystone OpenStack API endpoint) to `no_proxy`.