### PR TITLE
Fix double yaml file extention in manifests_path

### DIFF
--- a/modules/node/files/cloud-init.yml.tpl
+++ b/modules/node/files/cloud-init.yml.tpl
@@ -30,7 +30,7 @@ write_files:
     fi
 %{ if bootstrap_server == "" ~}
   %{~ for f in manifests_files ~}
-- path: /var/lib/rancher/rke2/server/manifests/${f[0]}.yaml
+- path: /var/lib/rancher/rke2/server/manifests/${f[0]}
   permissions: "0600"
   owner: root:root
   encoding: gz+b64


### PR DESCRIPTION
When using the `manifests_path` feature, it adds an extra `.yaml` file extension to the rendered files.

The `fileset` globs for the yaml extension and includes it in the `base64gzip`. The template doubles it.
https://github.com/remche/terraform-openstack-rke2/blob/master/modules/node/main.tf#L37

Files in the module.
```
~/Repos/datto/tf_rancher/modules/rke2 main* ❯ grep manifests main.tf
  manifests_path  = "${path.module}/manifests"

~/Repos/datto/tf_rancher/modules/rke2 main* ❯ ll manifests
total 128
-rw-r--r--  1 cpowell  staff   477B Jul 27  2022 snapshot-class.yaml
-rw-r--r--  1 cpowell  staff   2.6K Jun 20  2022 snapshot-controller.yaml
-rw-r--r--  1 cpowell  staff    53K Jun 20  2022 snapshotter-crds.yaml
```
Renders the following on disk.
```
root@test-server-001:/var/lib/rancher/rke2/server/manifests# ll
total 364
drwxr-xr-x 2 root root   4096 Jun 12 15:40 ./
drwxr-xr-x 8 root root   4096 Jun 10 15:32 ../
-rw-r--r-- 1 root root 185919 Jun 12 15:39 rke2-calico-crd.yaml
-rw-r--r-- 1 root root  17779 Jun 12 15:39 rke2-calico.yaml
-rw-r--r-- 1 root root  27797 Jun 12 15:39 rke2-coredns.yaml
-rw------- 1 root root    477 Jun  6 16:52 snapshot-class.yaml.yaml
-rw------- 1 root root   2676 Jun  6 16:52 snapshot-controller.yaml.yaml
-rw------- 1 root root  54735 Jun  6 16:52 snapshotter-crds.yaml.yaml
```
