### PR TITLE
Add additional_configs options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ If you need a template step for your manifests, you can use `manifests_gzb64` (s
 > [!WARNING]
 > Modifications made to manifests after cluster deployement wont have any effect.
 
+### Additional server config files
+Set the `additional_configs_path` variable to the directory containing your additional rke2 server configs. (see the [Audit Policy example](./examples/audit-policy/))
+
+If you need a template step for your manifests, you can use `additional_configs_gzb64`.
+
+> [!WARNING]
+> Modifications made to manifests after cluster deployement wont have any effect.
+
 ### Downscale
 
 You need to manually drain and remove node before downscaling a pool nodes.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ If you need a template step for your manifests, you can use `manifests_gzb64` (s
 ### Additional server config files
 Set the `additional_configs_path` variable to the directory containing your additional rke2 server configs. (see the [Audit Policy example](./examples/audit-policy/))
 
-If you need a template step for your manifests, you can use `additional_configs_gzb64`.
+If you need a template step for your config files, you can use `additional_configs_gzb64`.
 
 > [!WARNING]
 > Modifications made to manifests after cluster deployement wont have any effect.

--- a/examples/audit-policy/README.md
+++ b/examples/audit-policy/README.md
@@ -1,0 +1,3 @@
+# Audit Policy
+
+This is an example for adding additional rke2 config files.

--- a/examples/audit-policy/configs/audit-policy.yaml
+++ b/examples/audit-policy/configs/audit-policy.yaml
@@ -1,0 +1,5 @@
+# Log all requests at the Metadata level.
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata

--- a/examples/audit-policy/main.tf
+++ b/examples/audit-policy/main.tf
@@ -1,0 +1,10 @@
+module "controlplane" {
+  source                  = "remche/rke2/openstack"
+  cluster_name            = var.cluster_name
+  write_kubeconfig        = true
+  image_name              = "ubuntu-20.04-focal-x86_64"
+  flavor_name             = "genX2"
+  public_net_name         = "dmz"
+  rke2_config             = file("rke2_config.yaml")
+  additional_configs_path = "./configs"
+}

--- a/examples/audit-policy/outputs.tf
+++ b/examples/audit-policy/outputs.tf
@@ -1,0 +1,5 @@
+output "server_ip" {
+  description = "Server floating IP"
+  value       = module.controlplane.floating_ip[0]
+  sensitive   = true
+}

--- a/examples/audit-policy/rke2_config.yaml
+++ b/examples/audit-policy/rke2_config.yaml
@@ -1,0 +1,1 @@
+audit-policy-file: /etc/rancher/rke2/audit-policy.yaml

--- a/examples/audit-policy/variables.tf
+++ b/examples/audit-policy/variables.tf
@@ -1,0 +1,4 @@
+variable "cluster_name" {
+  type    = string
+  default = "audit-policy"
+}

--- a/main.tf
+++ b/main.tf
@@ -55,41 +55,43 @@ module "secgroup" {
 }
 
 module "server" {
-  source                 = "./modules/node"
-  cluster_name           = var.cluster_name
-  name_prefix            = "${var.cluster_name}-server"
-  nodes_count            = var.nodes_count
-  image_name             = var.image_name
-  image_id               = var.image_id
-  instance_tags          = var.instance_tags
-  flavor_name            = var.flavor_name
-  keypair_name           = module.keypair.keypair_name
-  ssh_key_file           = var.ssh_key_file
-  system_user            = var.system_user
-  use_ssh_agent          = var.use_ssh_agent
-  network_id             = module.network.nodes_net_id
-  subnet_id              = module.network.nodes_subnet_id
-  secgroup_id            = module.secgroup.secgroup_id
-  server_affinity        = var.server_group_affinity
-  assign_floating_ip     = "true"
-  config_drive           = var.nodes_config_drive
-  floating_ip_pool       = var.public_net_name
-  user_data              = var.user_data_file != null ? file(var.user_data_file) : null
-  boot_from_volume       = var.boot_from_volume
-  boot_volume_size       = var.boot_volume_size
-  boot_volume_type       = var.boot_volume_type
-  availability_zones     = var.availability_zones
-  rke2_version           = var.rke2_version
-  rke2_config            = var.rke2_config
-  containerd_config_file = var.containerd_config_file
-  registries_conf        = var.registries_conf
-  rke2_token             = random_string.rke2_token.result
-  additional_san         = var.additional_san
-  manifests_path         = var.manifests_path
-  manifests_gzb64        = var.manifests_gzb64
-  do_upgrade             = var.do_upgrade
-  proxy_url              = var.proxy_url
-  no_proxy               = concat(["localhost", "127.0.0.1", "169.254.169.254", "127.0.0.0/8", "169.254.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"], var.no_proxy)
+  source                   = "./modules/node"
+  cluster_name             = var.cluster_name
+  name_prefix              = "${var.cluster_name}-server"
+  nodes_count              = var.nodes_count
+  image_name               = var.image_name
+  image_id                 = var.image_id
+  instance_tags            = var.instance_tags
+  flavor_name              = var.flavor_name
+  keypair_name             = module.keypair.keypair_name
+  ssh_key_file             = var.ssh_key_file
+  system_user              = var.system_user
+  use_ssh_agent            = var.use_ssh_agent
+  network_id               = module.network.nodes_net_id
+  subnet_id                = module.network.nodes_subnet_id
+  secgroup_id              = module.secgroup.secgroup_id
+  server_affinity          = var.server_group_affinity
+  assign_floating_ip       = "true"
+  config_drive             = var.nodes_config_drive
+  floating_ip_pool         = var.public_net_name
+  user_data                = var.user_data_file != null ? file(var.user_data_file) : null
+  boot_from_volume         = var.boot_from_volume
+  boot_volume_size         = var.boot_volume_size
+  boot_volume_type         = var.boot_volume_type
+  availability_zones       = var.availability_zones
+  rke2_version             = var.rke2_version
+  rke2_config              = var.rke2_config
+  containerd_config_file   = var.containerd_config_file
+  registries_conf          = var.registries_conf
+  rke2_token               = random_string.rke2_token.result
+  additional_san           = var.additional_san
+  manifests_path           = var.manifests_path
+  manifests_gzb64          = var.manifests_gzb64
+  additional_configs_path  = var.additional_configs_path
+  additional_configs_gzb64 = var.additional_configs_gzb64
+  do_upgrade               = var.do_upgrade
+  proxy_url                = var.proxy_url
+  no_proxy                 = concat(["localhost", "127.0.0.1", "169.254.169.254", "127.0.0.0/8", "169.254.0.0/16", "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"], var.no_proxy)
 }
 
 resource "local_file" "tmpdirfile" {

--- a/modules/node/files/cloud-init.yml.tpl
+++ b/modules/node/files/cloud-init.yml.tpl
@@ -74,6 +74,22 @@ write_files:
     kube-apiserver-arg: "kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname"
     %{~ endif ~}
     ${indent(4,rke2_conf)}
+%{ if is_server ~}
+  %{~ for f in additional_config_files ~}
+- path: /etc/rancher/rke2/${f[0]}
+  permissions: "0600"
+  owner: root:root
+  encoding: gz+b64
+  content: ${f[1]}
+  %{~ endfor ~}
+  %{~ for k, v in manifests_gzb64 ~}
+- path: /etc/rancher/rke2/${k}
+  permissions: "0600"
+  owner: root:root
+  encoding: gz+b64
+  content: ${v}
+  %{~ endfor ~}
+%{ endif ~}
 %{ if proxy_url != null ~}
 - path: /etc/environment
   append: true

--- a/modules/node/main.tf
+++ b/modules/node/main.tf
@@ -23,21 +23,23 @@ resource "openstack_compute_instance_v2" "instance" {
   key_pair     = var.keypair_name
   config_drive = var.config_drive
   user_data = base64encode(templatefile(("${path.module}/files/cloud-init.yml.tpl"),
-    { cluster_name     = var.cluster_name
-      bootstrap_server = var.is_server && count.index != 0 ? openstack_networking_port_v2.port[0].all_fixed_ips[0] : var.bootstrap_server
-      public_address   = var.is_server ? openstack_networking_floatingip_v2.floating_ip[count.index].address : ""
-      rke2_token       = var.rke2_token
-      is_server        = var.is_server
-      san              = openstack_networking_floatingip_v2.floating_ip[*].address
-      system_user      = var.system_user
-      rke2_conf        = var.rke2_config
-      containerd_conf  = var.containerd_config_file
-      registries_conf  = var.registries_conf
-      additional_san   = var.additional_san
-      manifests_files  = var.manifests_path != "" ? [for f in fileset(var.manifests_path, "*.{yml,yaml}") : [f, base64gzip(file("${var.manifests_path}/${f}"))]] : []
-      manifests_gzb64  = var.manifests_gzb64
-      proxy_url        = var.proxy_url
-      no_proxy         = var.no_proxy
+    { cluster_name             = var.cluster_name
+      bootstrap_server         = var.is_server && count.index != 0 ? openstack_networking_port_v2.port[0].all_fixed_ips[0] : var.bootstrap_server
+      public_address           = var.is_server ? openstack_networking_floatingip_v2.floating_ip[count.index].address : ""
+      rke2_token               = var.rke2_token
+      is_server                = var.is_server
+      san                      = openstack_networking_floatingip_v2.floating_ip[*].address
+      system_user              = var.system_user
+      rke2_conf                = var.rke2_config
+      containerd_conf          = var.containerd_config_file
+      registries_conf          = var.registries_conf
+      additional_san           = var.additional_san
+      manifests_files          = var.manifests_path != "" ? [for f in fileset(var.manifests_path, "*.{yml,yaml}") : [f, base64gzip(file("${var.manifests_path}/${f}"))]] : []
+      manifests_gzb64          = var.manifests_gzb64
+      additional_config_files  = var.additional_configs_path != "" ? [for f in fileset(var.additional_configs_path, "*") : [f, base64gzip(file("${var.additional_configs_path}/${f}"))]] : []
+      additional_configs_gzb64 = var.additional_configs_gzb64
+      proxy_url                = var.proxy_url
+      no_proxy                 = var.no_proxy
   }))
   metadata = {
     rke2_version = var.rke2_version

--- a/modules/node/variables.tf
+++ b/modules/node/variables.tf
@@ -146,6 +146,17 @@ variable "additional_san" {
   description = "RKE additional SAN"
 }
 
+variable "additional_configs_path" {
+  type        = string
+  default     = ""
+  description = "RKE2 additional config files"
+}
+
+variable "additional_configs_gzb64" {
+  type    = map(string)
+  default = {}
+}
+
 variable "manifests_path" {
   type        = string
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -202,6 +202,17 @@ variable "additional_san" {
   description = "RKE2 additional SAN"
 }
 
+variable "additional_configs_path" {
+  type        = string
+  default     = ""
+  description = "RKE2 additional config files"
+}
+
+variable "additional_configs_gzb64" {
+  type        = map(string)
+  default     = {}
+  description = "RKE2 additional configs in gz+b64 in the form { \"config_file_name\": \"gzb64_manifests\" }"
+}
 variable "manifests_path" {
   type        = string
   default     = ""


### PR DESCRIPTION
Fixes #67 

Adds the ability to include additional config files for rke2 controlplane/servers.
Includes example.

I think keeping the manifest options are good as its a documented rke2 feature. I looked through the rke2 server config options and there are several options to add config files so I think this is the most generic version.